### PR TITLE
Fixing the event listener

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
   <head>
     <link rel = "icon" href = "favicon.ico">
     <link type = "text/css" rel = "stylesheet" href = "https://cdn.jsdelivr.net/gh/HunterBall/Fresh@1.1.1/fresh.min.css">
-    <script src = "https://cdn.jsdelivr.net/gh/HunterBall/Fresh@1.1.1/fresh.min.js"></script>
     <style>
       .hero{
         background-image:  linear-gradient( rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5) ), url('rice.jpg');
@@ -101,5 +100,6 @@
     </div>
     <br>
     <br>
+    <script src = "https://cdn.jsdelivr.net/gh/HunterBall/Fresh@1.1.1/fresh.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
I saw that the referenced script was attempting to place an event listener onto the document body before it loaded, so I moved the script to a place where a reference to document.body wouldn't return null. It would likely be possible to produce the same effect by deferring the loading of the script, but I don't ever do that, so I'm not as comfortable making that change.

Also, I think the About section of the GitHub page could benefit from what I put in that section in my fork of the repository, but I can't make a pull request for that.